### PR TITLE
T19 Add Lambda for piping logs to Elasticsearch

### DIFF
--- a/log_group_subscriber/es.py
+++ b/log_group_subscriber/es.py
@@ -1,0 +1,62 @@
+import gzip
+import json
+from base64 import b64decode
+from datetime import date
+
+import boto3
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+from requests_aws4auth import AWS4Auth
+
+from log_group_subscriber.util import getenv
+
+AWS_REGION = getenv("AWS_REGION")
+ES_API_ENDPOINT = getenv("ES_API_ENDPOINT")
+ES_INDEX_PREFIX = getenv("ES_INDEX_PREFIX")
+
+_ES_CLIENT = None
+
+
+def _es_client():
+    global _ES_CLIENT
+
+    if not _ES_CLIENT:
+        credentials = boto3.Session().get_credentials()
+        awsauth = AWS4Auth(
+            credentials.access_key,
+            credentials.secret_key,
+            AWS_REGION,
+            "es",
+            session_token=credentials.token,
+        )
+        _ES_CLIENT = Elasticsearch(
+            hosts=[{"host": ES_API_ENDPOINT, "scheme": "https", "port": 443}],
+            http_auth=awsauth,
+            use_ssl=True,
+            verify_certs=True,
+            connection_class=RequestsHttpConnection,
+            timeout=2,
+        )
+    return _ES_CLIENT
+
+
+def _es_body_from_log_event(log_event):
+    body = json.loads(log_event["message"])
+
+    if "id" in log_event:
+        body["@id"] = log_event["id"]
+    if "timestamp" in body:
+        body["@timestamp"] = body["timestamp"]
+    if "message" in log_event:
+        body["@message"] = log_event["message"]
+
+    return body
+
+
+def cloudwatch_to_es(event):
+    es = _es_client()
+    index = "{}-{}".format(ES_INDEX_PREFIX, date.today().isoformat())
+    message = json.loads(
+        gzip.decompress(b64decode(event["awslogs"]["data"])).decode("utf-8")
+    )
+    for body in map(_es_body_from_log_event, message["logEvents"]):
+        es.index(index=index, doc_type="log", body=body)

--- a/log_group_subscriber/es.py
+++ b/log_group_subscriber/es.py
@@ -1,7 +1,8 @@
 import gzip
 import json
 from base64 import b64decode
-from datetime import date
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import boto3
 from elasticsearch import Elasticsearch, RequestsHttpConnection
@@ -54,7 +55,10 @@ def _es_body_from_log_event(log_event):
 
 def cloudwatch_to_es(event):
     es = _es_client()
-    index = "{}-{}".format(ES_INDEX_PREFIX, date.today().isoformat())
+    index = "{}-{}".format(
+        ES_INDEX_PREFIX,
+        datetime.now(ZoneInfo("Europe/Oslo")).date().isoformat(),
+    )
     message = json.loads(
         gzip.decompress(b64decode(event["awslogs"]["data"])).decode("utf-8")
     )

--- a/log_group_subscriber/handlers.py
+++ b/log_group_subscriber/handlers.py
@@ -1,0 +1,19 @@
+from aws_xray_sdk.core import patch_all, xray_recorder
+from okdata.aws.logging import logging_wrapper
+
+from log_group_subscriber.es import cloudwatch_to_es
+from log_group_subscriber.subscription import handle_new_log_group
+
+patch_all()
+
+
+@logging_wrapper
+@xray_recorder.capture("new_log_group")
+def new_log_group(event, context):
+    handle_new_log_group(event["detail"]["requestParameters"]["logGroupName"])
+
+
+@logging_wrapper
+@xray_recorder.capture("cloudwatch_event")
+def cloudwatch_event(event, context):
+    cloudwatch_to_es(event)

--- a/log_group_subscriber/subscription.py
+++ b/log_group_subscriber/subscription.py
@@ -2,12 +2,8 @@ import os
 import re
 
 import boto3
-from aws_xray_sdk.core import patch_all, xray_recorder
-from okdata.aws.logging import logging_wrapper
 
 from log_group_subscriber.util import getenv
-
-patch_all()
 
 DESTINATION_ARN = getenv("DESTINATION_ARN")
 SUBSCRIPTION_WHITELIST = os.getenv("SUBSCRIPTION_WHITELIST")
@@ -33,7 +29,7 @@ def _log_group_filter_name(log_group_name):
     return "{}-filter".format(log_group_name.strip("/").replace("/", "-"))
 
 
-def _handle_new_log_group(log_group_name):
+def handle_new_log_group(log_group_name):
     """Handle a new log group.
 
     Return True if a subscription was created, otherwise return False.
@@ -49,9 +45,3 @@ def _handle_new_log_group(log_group_name):
     )
 
     return True
-
-
-@logging_wrapper
-@xray_recorder.capture("handle_new_log_group")
-def handle_new_log_group(event, context):
-    _handle_new_log_group(event["detail"]["requestParameters"]["logGroupName"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,19 +10,23 @@ attrs==21.2.0
     # via jsonschema
 aws-xray-sdk==2.8.0
     # via okdata-log-group-subscriber (setup.py)
-boto3==1.19.6
+boto3==1.20.8
     # via okdata-log-group-subscriber (setup.py)
-botocore==1.22.6
+botocore==1.23.9
     # via
     #   aws-xray-sdk
     #   boto3
     #   s3transfer
 certifi==2021.10.8
-    # via requests
+    # via
+    #   elasticsearch
+    #   requests
 charset-normalizer==2.0.7
     # via requests
 ecdsa==0.17.0
     # via python-jose
+elasticsearch==7.13.4
+    # via okdata-log-group-subscriber (setup.py)
 future==0.18.2
     # via aws-xray-sdk
 idna==3.3
@@ -33,7 +37,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-jsonschema==4.1.2
+jsonschema==4.2.1
     # via okdata-sdk
 okdata-aws==1.0.0
     # via okdata-log-group-subscriber (setup.py)
@@ -60,6 +64,9 @@ requests==2.26.0
     #   okdata-aws
     #   okdata-sdk
     #   python-keycloak
+    #   requests-aws4auth
+requests-aws4auth==1.1.1
+    # via okdata-log-group-subscriber (setup.py)
 rsa==4.7.2
     # via python-jose
 s3transfer==0.5.0
@@ -68,17 +75,19 @@ six==1.16.0
     # via
     #   ecdsa
     #   python-dateutil
+    #   requests-aws4auth
 sniffio==1.2.0
     # via anyio
-starlette==0.16.0
+starlette==0.17.1
     # via okdata-aws
 structlog==21.2.0
     # via okdata-aws
-typing-extensions==3.10.0.2
+typing-extensions==4.0.0
     # via pydantic
 urllib3==1.26.7
     # via
     #   botocore
+    #   elasticsearch
     #   requests
-wrapt==1.13.2
+wrapt==1.13.3
     # via aws-xray-sdk

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -24,10 +24,12 @@ provider:
     STAGE: ${self:provider.stage}
     VERSION: ${self:custom.version}
     SERVICE_NAME: ${self:service}
-    # DESTINATION_ARN: TODO
+    DESTINATION_ARN: arn:aws:lambda:#{AWS::Region}:#{AWS::AccountId}:function:${self:service}-${self:provider.stage}-cloudwatch-event
     SUBSCRIPTION_WHITELIST: (/aws/lambda/[\w-]+)|teams-api|api-catalog-backend
-    SUBSCRIPTION_BLACKLIST: -es-logs-plugin$
+    SUBSCRIPTION_BLACKLIST: -es-logs-plugin$|-cloudwatch-event$
     FILTER_PATTERN: "{ $.function_name = \"*\" }"
+    ES_API_ENDPOINT: ${ssm:/dataplatform/shared/logs-elasticsearch-endpoint}
+    ES_INDEX_PREFIX: dataplatform-services
 package:
   exclude:
     - '**/*'
@@ -35,8 +37,8 @@ package:
     - log_group_subscriber/*.py
 
 functions:
-  handle_new_log_group:
-    handler: log_group_subscriber.handler.handle_new_log_group
+  new-log-group:
+    handler: log_group_subscriber.handlers.new_log_group
     events:
       - cloudwatchEvent:
           event:
@@ -49,6 +51,8 @@ functions:
                 - "logs.amazonaws.com"
               eventName:
                 - "CreateLogGroup"
+  cloudwatch-event:
+    handler: log_group_subscriber.handlers.cloudwatch_event
 
 plugins:
   - serverless-es-logs

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,10 @@ setup(
     install_requires=[
         "aws-xray-sdk",
         "boto3",
+        # XXX: Don't upgrade this package to 7.14 or later, since it doesn't
+        # work with AWS' OpenSearch Service.
+        "elasticsearch<7.14",
         "okdata-aws",
+        "requests-aws4auth",
     ],
 )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,41 @@
+import base64
+import gzip
+import json
+
+import pytest
+
+
+@pytest.fixture
+def log_group_event():
+    return {"detail": {"requestParameters": {"logGroupName": "/aws/lambda/foo"}}}
+
+
+@pytest.fixture
+def log_event():
+    return {
+        "id": "9481760491939405",
+        "timestamp": 1635862772240,
+        "message": '{"service_name": "foo", "handler_method": "async_handler", "function_name": "foo-dev-bar", "function_version": "$LATEST", "function_stage": "dev", "function_api_id": "6fc30dd3c8", "git_rev": "test:842694b", "aws_account_id": "123456789101", "aws_request_id": "d0908999-c343-6e1b-36a8-afb246b38387", "aws_trace_id": "Root=0-2df94e61-38c671fee0cb1bc0450068f3", "memory_limit_in_mb": "128", "logged_in": false, "principal_id": null, "source_ip": "123.45.678.x", "request_domain_name": "1ceb9b5668.execute-api.eu-west-1.amazonaws.com", "request_resource": "/", "request_path": "/", "request_method": "GET", "request_path_parameters": null, "request_query_string_parameters": {}, "cold_start": true, "hello": "world", "response_status_code": 200, "level": "info", "duration_ms": 59.042201, "event": "", "timestamp": "2021-11-02T14:19:32.240285Z"}\n',
+    }
+
+
+@pytest.fixture
+def cw_event(log_event):
+    return {
+        "awslogs": {
+            "data": base64.b64encode(
+                gzip.compress(
+                    json.dumps(
+                        {
+                            "messageType": "DATA_MESSAGE",
+                            "owner": "123456789101",
+                            "logGroup": "/aws/lambda/foo",
+                            "logStream": "2021/11/02/[$LATEST]ecb0714347e39edfa12a7d6173da8fd1",
+                            "subscriptionFilters": ["aws-lambda-foo-dev-bar-filter"],
+                            "logEvents": [log_event],
+                        }
+                    ).encode("utf-8")
+                )
+            )
+        }
+    }

--- a/test/test_es.py
+++ b/test/test_es.py
@@ -1,4 +1,8 @@
-from log_group_subscriber.es import _es_body_from_log_event
+from datetime import date
+
+from freezegun import freeze_time
+
+from log_group_subscriber.es import _es_body_from_log_event, _index_name, _log_date
 
 
 def test_es_body_from_log_event(log_event):
@@ -8,3 +12,26 @@ def test_es_body_from_log_event(log_event):
     assert body["@id"] == "9481760491939405"
     assert body["@message"] == log_event["message"]
     assert body["@timestamp"] == "2021-11-02T14:19:32.240285Z"
+
+
+def test_log_date(log_event):
+    assert _log_date(_es_body_from_log_event(log_event)) == date(2021, 11, 2)
+
+
+@freeze_time("2020-01-01T16:00:00+00:00")
+def test_log_date_missing_timestamp(log_event):
+    body = _es_body_from_log_event(log_event)
+    del body["timestamp"]
+    assert _log_date(body) == date(2020, 1, 1)
+
+
+def test_index_name(log_event):
+    body = _es_body_from_log_event(log_event)
+    assert _index_name(body) == "dataplatform-services-2021-11-02"
+
+
+@freeze_time("2020-01-01T16:00:00+00:00")
+def test_index_name_missing_timestamp(log_event):
+    body = _es_body_from_log_event(log_event)
+    del body["timestamp"]
+    assert _index_name(body) == "dataplatform-services-2020-01-01"

--- a/test/test_es.py
+++ b/test/test_es.py
@@ -1,0 +1,10 @@
+from log_group_subscriber.es import _es_body_from_log_event
+
+
+def test_es_body_from_log_event(log_event):
+    body = _es_body_from_log_event(log_event)
+
+    assert body["service_name"] == "foo"
+    assert body["@id"] == "9481760491939405"
+    assert body["@message"] == log_event["message"]
+    assert body["@timestamp"] == "2021-11-02T14:19:32.240285Z"

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock, patch
+
+from aws_xray_sdk.core import xray_recorder
+
+from log_group_subscriber.handlers import cloudwatch_event, new_log_group
+
+xray_recorder.begin_segment("Test")
+
+
+def test_new_log_group(log_group_event):
+    with patch("log_group_subscriber.subscription.boto3") as mock_boto:
+        mock_logs_client = Mock()
+        mock_boto.client.return_value = mock_logs_client
+
+        new_log_group(log_group_event, None)
+
+        mock_logs_client.put_subscription_filter.assert_called_once()
+
+
+def test_cloudwatch_event(cw_event):
+    with patch("log_group_subscriber.es._es_client") as _es_client:
+        mock_es_client = Mock()
+        _es_client.return_value = mock_es_client
+
+        cloudwatch_event(cw_event, None)
+
+        mock_es_client.index.assert_called_once()

--- a/test/test_subscription.py
+++ b/test/test_subscription.py
@@ -1,12 +1,6 @@
-from unittest.mock import Mock, patch
-
 from aws_xray_sdk.core import xray_recorder
 
-from log_group_subscriber.handler import (
-    _log_group_filter_name,
-    _should_subscribe,
-    handle_new_log_group,
-)
+from log_group_subscriber.subscription import _log_group_filter_name, _should_subscribe
 
 xray_recorder.begin_segment("Test")
 
@@ -23,16 +17,3 @@ def test_should_subscribe():
 
 def test_log_group_filter_name():
     assert _log_group_filter_name("/aws/lambda/foo") == "aws-lambda-foo-filter"
-
-
-def test_handle_new_log_group():
-    with patch("log_group_subscriber.handler.boto3") as mock_boto:
-        mock_logs_client = Mock()
-        mock_boto.client.return_value = mock_logs_client
-
-        handle_new_log_group(
-            {"detail": {"requestParameters": {"logGroupName": "/aws/lambda/foo"}}},
-            None,
-        )
-
-        mock_logs_client.put_subscription_filter.assert_called_once()

--- a/tox.ini
+++ b/tox.ini
@@ -6,18 +6,21 @@ deps =
     pytest
     -r requirements.txt
 commands =
-    pytest -s {posargs}
+    pytest {posargs}
 setenv =
+    AWS_REGION=eu-west-1
     AWS_ACCESS_KEY_ID = mock
     AWS_SECRET_ACCESS_KEY = mock
     SERVICE_NAME=okdata-log-group-subscriber
     DESTINATION_ARN=foo:bar:baz
     SUBSCRIPTION_WHITELIST=(/aws/lambda/[\w-]+)|teams-api|api-catalog-backend
-    SUBSCRIPTION_BLACKLIST=-es-logs-plugin$
+    SUBSCRIPTION_BLACKLIST=-es-logs-plugin$|-cloudwatch-event$
     # Matches log entries currently produced by the `okdata-aws`
     # logger. Only log entries matching this pattern are sent to the
     # destination
     FILTER_PATTERN=\{ $.function_name = "*" \}
+    ES_API_ENDPOINT=https://example.org
+    ES_INDEX_PREFIX=dataplatform-services
 
 [testenv:flake8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py39, flake8, black
 
 [testenv]
 deps =
+    freezegun
     pytest
     -r requirements.txt
 commands =


### PR DESCRIPTION
Add the target Lambda that receives logs from CloudWatch and forwards them to Elasticsearch.