### PR TITLE
Bump Node.js versions in deploy actions

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -20,9 +20,9 @@ jobs:
       run: pip install tox
     - name: Test with tox
       run: tox -e py,flake8,black
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
       with:
-        node-version: '12.x'
+        node-version: '18.x'
     - name: Install NPM dependencies
       run: npm install
     - name: Deploy Lambda functions

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,9 +18,9 @@ jobs:
       run: pip install tox
     - name: Test with tox
       run: tox -e py,flake8,black
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
       with:
-        node-version: '12.x'
+        node-version: '18.x'
     - name: Install NPM dependencies
       run: npm install
     - name: Deploy Lambda functions


### PR DESCRIPTION
Bump the Node.js versions used in the GitHub Actions for deployment since it's required by our current version of Serverless.