### PR TITLE
Increase default Elasticsearch timeout

### DIFF
--- a/log_group_subscriber/es.py
+++ b/log_group_subscriber/es.py
@@ -35,7 +35,7 @@ def _es_client():
             use_ssl=True,
             verify_certs=True,
             connection_class=RequestsHttpConnection,
-            timeout=2,
+            timeout=4,
         )
     return _ES_CLIENT
 


### PR DESCRIPTION
Double the timeout used by default for Elasticsearch connections from 2 seconds to 4 seconds to see if that helps with the timeout issues we've been seeing lately.