### PR TITLE
Increase default Elasticsearch timeout more

### DIFF
--- a/log_group_subscriber/es.py
+++ b/log_group_subscriber/es.py
@@ -35,7 +35,7 @@ def _es_client():
             use_ssl=True,
             verify_certs=True,
             connection_class=RequestsHttpConnection,
-            timeout=4,
+            timeout=8,
         )
     return _ES_CLIENT
 

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -56,6 +56,7 @@ functions:
                 - "CreateLogGroup"
   cloudwatch-event:
     handler: log_group_subscriber.handlers.cloudwatch_event
+    timeout: 10
 
 plugins:
   - serverless-better-credentials # must be first


### PR DESCRIPTION
Double the timeout used by default for Elasticsearch connections again, this time from 4 seconds to 8 seconds.